### PR TITLE
Use plugin version for asset loading

### DIFF
--- a/includes/class-wp-post-queue-admin.php
+++ b/includes/class-wp-post-queue-admin.php
@@ -60,7 +60,7 @@ class Admin {
 			'wp-queue-plugin',
 			plugins_url( '/build/editor.js', __DIR__ ),
 			array( 'wp-plugins', 'wp-edit-post', 'wp-element', 'wp-components', 'wp-data' ),
-			filemtime( plugin_dir_path( __DIR__ ) . 'build/editor.js' ),
+			WP_POST_QUEUE_VERSION,
 			true
 		);
 	}
@@ -100,7 +100,7 @@ class Admin {
 				'wp-queue-settings-panel-script',
 				plugins_url( '/build/settings-panel.js', __DIR__ ),
 				array( 'wp-element', 'wp-components', 'wp-data', 'wp-api', 'wp-api-fetch', 'wp-redux-routine' ),
-				filemtime( plugin_dir_path( __DIR__ ) . 'build/settings-panel.js' ),
+				WP_POST_QUEUE_VERSION,
 				true
 			);
 
@@ -122,7 +122,7 @@ class Admin {
 				'drag-drop-reorder',
 				plugins_url( '/build/drag-drop-reorder.js', __DIR__ ),
 				array( 'wp-data', 'wp-api', 'wp-api-fetch' ),
-				'1.0',
+				WP_POST_QUEUE_VERSION,
 				true
 			);
 		}
@@ -142,14 +142,14 @@ class Admin {
 				'wp-queue-settings-panel-css',
 				plugins_url( '/build/settings-panel.css', __DIR__ ),
 				array( 'wp-components', 'wp-preferences' ),
-				'1.0.0'
+				WP_POST_QUEUE_VERSION
 			);
 
 			wp_enqueue_style(
 				'wp-queue-drag-drop-css',
 				plugins_url( '/build/drag-drop-reorder.css', __DIR__ ),
 				array(),
-				'1.0.0'
+				WP_POST_QUEUE_VERSION
 			);
 		}
 	}

--- a/wp-post-queue.php
+++ b/wp-post-queue.php
@@ -12,6 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
+define( 'WP_POST_QUEUE_VERSION', '0.1.0' );
+
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-wp-post-queue.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-wp-post-queue-rest-api.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-wp-post-queue-admin.php';


### PR DESCRIPTION
@rtio reported an error with loading some of the assets like `settings-panel`. We don't need a dynamic file modification now anyway. We can use the plugin version I think.

Test build: [wp-post-queue.zip](https://github.com/user-attachments/files/17438067/wp-post-queue.zip)
