### PR TITLE
Fix up docblocks and formatting for tests and a GitHub Action for running WordPress Tests

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -1,0 +1,65 @@
+name: PHPUnit Tests
+
+on:
+  push:
+    branches: [ trunk, develop ]
+  pull_request:
+    branches: [ trunk, develop ]
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: wordpress_test
+          MYSQL_USER: wp_test
+          MYSQL_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping --silent"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          tools: composer
+
+      - name: Install MySQL Client
+        run: sudo apt-get update && sudo apt-get install -y mysql-client
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Download WordPress
+        run: |
+          curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+          chmod +x wp-cli.phar
+          sudo mv wp-cli.phar /usr/local/bin/wp
+          wp core download --path=/tmp/wordpress --allow-root
+
+      - name: Setup WordPress configuration
+        run: |
+          wp config create --path=/tmp/wordpress --dbname=wordpress_test --dbuser=wp_test --dbpass=password --dbhost=127.0.0.1 --skip-check --allow-root
+
+      - name: Install WordPress
+        run: wp core install --path=/tmp/wordpress --url=http://localhost --title="Test" --admin_user=admin --admin_password=admin --admin_email=admin@example.com --allow-root
+
+      - name: Install WordPress Test Suite
+        env:
+          DELETE_EXISTING_DB: "y"
+        run: |
+          bash bin/install-wp-tests.sh wordpress_test wp_test password 127.0.0.1 latest --allow-root
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -11,7 +11,6 @@
 	<!-- Exclude node modules and vendor folders -->
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>vendor/*</exclude-pattern>
-	<exclude-pattern>tests/*</exclude-pattern>
 
 	<!-- Check that the proper text domain(s) is used everywhere. -->
 	<rule ref="WordPress.WP.I18n">

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -169,7 +169,9 @@ install_db() {
 	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
 	then
 		echo "Reinstalling will delete the existing test database ($DB_NAME)"
-		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
+		if [ -z "$DELETE_EXISTING_DB" ]; then
+			read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
+		fi
 		recreate_db $DELETE_EXISTING_DB
 	else
 		create_db

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -27,9 +27,11 @@ require_once "{$_tests_dir}/includes/functions.php";
 
 /**
  * Manually load the plugin being tested.
+ *
+ * @return void
  */
 function _manually_load_plugin() {
-	require dirname( dirname( __FILE__ ) ) . '/wp-post-queue.php';
+	require dirname( __DIR__ ) . '/wp-post-queue.php';
 }
 
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );

--- a/tests/class-wp-post-queue-admin-test.php
+++ b/tests/class-wp-post-queue-admin-test.php
@@ -10,6 +10,11 @@ class Test_WP_Post_Queue_Admin extends WP_UnitTestCase {
 	private $admin;
 	private $settings;
 
+	/**
+	 * Sets up the tests.
+	 *
+	 * @return void
+	 */
 	public function setUp(): void {
 		parent::setUp();
 		$this->settings = array(
@@ -21,21 +26,21 @@ class Test_WP_Post_Queue_Admin extends WP_UnitTestCase {
 		$this->admin    = new Admin( $this->settings );
 	}
 
-	public function tearDown(): void {
-		parent::tearDown();
-	}
-
 	/**
 	 * Test the registration of the post status "queued", making sure it's in the registered post statuses.
+	 *
+	 * @return void
 	 */
 	public function test_register_post_status() {
 		$this->admin->register_post_status();
-		$this->assertTrue( in_array( 'queued', get_post_stati() ), 'The post status "queued" should be registered.' );
+		$this->assertTrue( in_array( 'queued', get_post_stati(), true ), 'The post status "queued" should be registered.' );
 	}
 
 	/**
 	 * Test the modification of post labels when the post status is "queued".
 	 * On the edit page only, the post labels should be modified to "Queue" instead of "Posts".
+	 *
+	 * @return void
 	 */
 	public function test_modify_post_labels() {
 		global $pagenow;
@@ -59,6 +64,8 @@ class Test_WP_Post_Queue_Admin extends WP_UnitTestCase {
 	/**
 	 * Test the conditional addition of the drag handle column.
 	 * The drag handle column should be added only when the post status is "queued".
+	 *
+	 * @return void
 	 */
 	public function test_conditionally_add_drag_handle_column() {
 		$columns = array(
@@ -77,6 +84,8 @@ class Test_WP_Post_Queue_Admin extends WP_UnitTestCase {
 	/**
 	 * Test the display of post states when the post status is "queued".
 	 * The post states should include "Queued" next to the post title in the admin.
+	 *
+	 * @return void
 	 */
 	public function test_display_post_states() {
 		$post        = $this->factory->post->create_and_get( array( 'post_status' => 'queued' ) );
@@ -88,6 +97,8 @@ class Test_WP_Post_Queue_Admin extends WP_UnitTestCase {
 	/**
 	 * Test the post date column status when the post status is "queued".
 	 * The post date column status should be "Queued" when the post status is "queued", instead of "Last Modified".
+	 *
+	 * @return void
 	 */
 	public function test_post_date_column_status() {
 		$post   = $this->factory->post->create_and_get( array( 'post_status' => 'queued' ) );
@@ -99,6 +110,8 @@ class Test_WP_Post_Queue_Admin extends WP_UnitTestCase {
 	/**
 	 * Test the registration of settings.
 	 * The settings "wp_queue_publish_times", "wp_queue_start_time", "wp_queue_end_time", and "wp_queue_paused" should be registered.
+	 *
+	 * @return void
 	 */
 	public function test_register_settings() {
 		$this->admin->register_settings();
@@ -111,6 +124,8 @@ class Test_WP_Post_Queue_Admin extends WP_UnitTestCase {
 	/**
 	 * Test the addition and highlighting of the queue menu item.
 	 * The menu item should be added and highlighted correctly when the post status is "queued".
+	 *
+	 * @return void
 	 */
 	public function test_adds_and_highlight_queue_menu_item() {
 		global $parent_file, $submenu_file, $pagenow;
@@ -127,6 +142,8 @@ class Test_WP_Post_Queue_Admin extends WP_UnitTestCase {
 	 * Test the set default queue order method.
 	 * The method should set the default rderby and order of the query to "date" and "ASC" when the post status is "queued".
 	 * This way we can see the next to be published post at the top of the list.
+	 *
+	 * @return void
 	 */
 	public function test_set_default_queue_order() {
 		set_current_screen( 'edit-post' );

--- a/tests/class-wp-post-queue-rest-api-test.php
+++ b/tests/class-wp-post-queue-rest-api-test.php
@@ -10,6 +10,11 @@ class Test_WP_Post_Queue_REST_API extends WP_UnitTestCase {
 	private $rest_api;
 	private $settings;
 
+	/**
+	 * Sets up the tests.
+	 *
+	 * @return void
+	 */
 	public function setUp(): void {
 		parent::setUp();
 		$this->settings = array(
@@ -20,13 +25,10 @@ class Test_WP_Post_Queue_REST_API extends WP_UnitTestCase {
 		);
 		$this->rest_api = new REST_API( $this->settings );
 	}
-
-	public function tearDown(): void {
-		parent::tearDown();
-	}
-
 	/**
 	 * Test that the get_settings method returns the correct settings from the database.
+	 *
+	 * @return void
 	 */
 	public function test_get_settings() {
 		$settings = $this->rest_api->get_settings();
@@ -40,6 +42,8 @@ class Test_WP_Post_Queue_REST_API extends WP_UnitTestCase {
 
 	/**
 	 * Test that the update_settings method updates the settings in the database correctly.
+	 *
+	 * @return void
 	 */
 	public function test_update_settings() {
 		$request = new WP_REST_Request( 'POST', '/wp-post-queue/v1/settings' );
@@ -62,6 +66,8 @@ class Test_WP_Post_Queue_REST_API extends WP_UnitTestCase {
 
 	/**
 	 * Test that the recalculate_publish_times_rest_callback method recalculates the publish times for all posts in the queue correctly.
+	 *
+	 * @return void
 	 */
 	public function test_recalculate_publish_times_rest_callback() {
 		$post_ids = array(
@@ -87,6 +93,8 @@ class Test_WP_Post_Queue_REST_API extends WP_UnitTestCase {
 	/**
 	 * Test that the endpoint returns a 200 status code and data when called correctly
 	 * Note that we check the actual sorting logic in the Manager class, instead of trying to test it twice.
+	 *
+	 * @return void
 	 */
 	public function test_shuffle_queue() {
 		$post_ids = array(


### PR DESCRIPTION
The `tests/` folder is currently ignored by PHPUnit (for some reason this was from the test suite / WP scaffolding). This PR unignores it and fixes a few additional formatting issues, mostly around docblocks. 

This PR also adds a new [GitHub action](https://github.com/Automattic/wp-post-queue/commit/886d656e2858c6275f2b065ce848f8305ae31d2c) for running the WordPress/PHPUnit tests on PRs and in trunk.

## Testing Instructions
* Make sure all PR checks for this branch pass