### PR TITLE
Update how timezones are displayed and make sure queue times are recalculated when the timezone setting changes

### DIFF
--- a/client/settings-panel/index.js
+++ b/client/settings-panel/index.js
@@ -149,13 +149,12 @@ const SettingsPanel = ( {
 
 	const getTimezoneDisplay = ( timezone, gmtOffset ) => {
 		if ( timezone && ! timezone.includes( 'Etc/GMT' ) ) {
-			return timezone; // Directly return if it's a named timezone
+			return timezone;
 		}
 
 		let tzstring = '';
 		if ( ! timezone || timezone.includes( 'Etc/GMT' ) ) {
-			const offset = parseFloat( gmtOffset ); // Ensure it's a float for fractional offsets
-			console.log( 'offset', offset );
+			const offset = parseFloat( gmtOffset );
 			if ( offset === 0 ) {
 				tzstring = 'UTC+0';
 			} else if ( offset < 0 ) {

--- a/client/settings-panel/index.js
+++ b/client/settings-panel/index.js
@@ -147,6 +147,40 @@ const SettingsPanel = ( {
 			} );
 	};
 
+	const getTimezoneDisplay = ( timezone, gmtOffset ) => {
+		if ( timezone && ! timezone.includes( 'Etc/GMT' ) ) {
+			return timezone; // Directly return if it's a named timezone
+		}
+
+		let tzstring = '';
+		if ( ! timezone || timezone.includes( 'Etc/GMT' ) ) {
+			const offset = parseFloat( gmtOffset ); // Ensure it's a float for fractional offsets
+			console.log( 'offset', offset );
+			if ( offset === 0 ) {
+				tzstring = 'UTC+0';
+			} else if ( offset < 0 ) {
+				tzstring = `UTC${ offset }`;
+			} else {
+				tzstring = `UTC+${ offset }`;
+			}
+		}
+
+		return tzstring;
+	};
+
+	const getLocalDateTime = ( gmtOffset ) => {
+		try {
+			const date = new Date();
+			const utcTime = date.getTime() + date.getTimezoneOffset() * 60000;
+			const offsetInMilliseconds = parseFloat( gmtOffset ) * 3600 * 1000;
+			const localTime = new Date( utcTime + offsetInMilliseconds );
+			return localTime.toLocaleString();
+		} catch ( _error ) {
+			console.error( 'Error getting local date and time:', _error );
+			return __( 'N/A', 'wp-post-queue' );
+		}
+	};
+
 	return (
 		<div className="settings-panel">
 			<p>
@@ -253,11 +287,18 @@ const SettingsPanel = ( {
 
 			<p>
 				{ __( 'Timezone:', 'wp-post-queue' ) }{ ' ' }
-				{ wpQueuePluginData.timezone } (
+				{ getTimezoneDisplay(
+					wpQueuePluginData.timezone,
+					wpQueuePluginData.gmtOffset
+				) }{ ' ' }
+				(
 				<a href={ wpQueuePluginData.settingsUrl }>
 					{ __( 'change', 'wp-post-queue' ) }
 				</a>
 				)
+				<br />
+				{ __( 'Local Time:', 'wp-post-queue' ) }{ ' ' }
+				{ getLocalDateTime( wpQueuePluginData.gmtOffset ) }
 			</p>
 			<div className="settings-actions">
 				<Button isSecondary onClick={ shuffleQueue }>

--- a/tests/class-wp-post-queue-manager-test.php
+++ b/tests/class-wp-post-queue-manager-test.php
@@ -555,7 +555,6 @@ class Test_WP_Post_Queue_Manager extends WP_UnitTestCase {
 		$index             = 0;
 		$last_publish_time = null;
 
-		// Adjust the last_publish_time for the GMT offset
 		if ( null !== $last_publish_time ) {
 			$last_publish_time += $gmt_offset * 3600;
 		}

--- a/tests/class-wp-post-queue-manager-test.php
+++ b/tests/class-wp-post-queue-manager-test.php
@@ -26,8 +26,13 @@ class Test_WP_Post_Queue_Manager extends WP_UnitTestCase {
 
 		$this->manager = $this->getMockBuilder( Manager::class )
 			->setConstructorArgs( array( $this->settings ) )
-			->onlyMethods( array( 'get_current_time' ) )
+			->onlyMethods( array( 'get_current_time', 'get_current_date' ) )
 			->getMock();
+
+		// Mock the get_current_date method to return a DateTime object
+		$current_date = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
+		$this->manager->method( 'get_current_date' )
+			->willReturn( $current_date );
 	}
 
 	/**
@@ -227,12 +232,16 @@ class Test_WP_Post_Queue_Manager extends WP_UnitTestCase {
 	public function test_calculate_next_publish_time( $settings, $expected_times, $queued_posts, $current_time = null ) {
 		$this->manager = $this->getMockBuilder( Manager::class )
 			->setConstructorArgs( array( $settings ) )
-			->onlyMethods( array( 'get_current_time' ) )
+			->onlyMethods( array( 'get_current_time', 'get_current_date' ) )
 			->getMock();
 
 		$current_time = $current_time ?? strtotime( 'today 23:59:59' );
 		$this->manager->method( 'get_current_time' )
 			->willReturn( $current_time );
+
+		$current_date = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
+		$this->manager->method( 'get_current_date' )
+			->willReturn( $current_date );
 
 		$calculated_times = array();
 		$post_mocks       = array();
@@ -420,6 +429,140 @@ class Test_WP_Post_Queue_Manager extends WP_UnitTestCase {
 			$next_scheduled = wp_next_scheduled( 'publish_queued_post', array( $post_id ) );
 			$this->assertNotFalse( $next_scheduled, 'The post should be rescheduled for publishing when resumed.' );
 		}
+	}
+
+	/**
+	 * Data provider for test_calculate_next_publish_time_with_gmt_offset.
+	 *
+	 * @return array
+	 */
+	public function gmtOffsetProvider() {
+		return array(
+			'GMT offset 0'              => array(
+				'settings'      => array(
+					'publishTimes' => 2,
+					'startTime'    => '12:00 AM',
+					'endTime'      => '1:00 AM',
+				),
+				'gmt_offset'    => 0,
+				'current_date'  => '2023-10-01',
+				'current_time'  => '05:00:00',
+				// Expected time is the next day at 12:20am, since the time has passed for today
+				'expected_time' => strtotime( '2023-10-02 00:20:00' ),
+			),
+			'GMT offset 0 but its 12am' => array(
+				'settings'      => array(
+					'publishTimes' => 2,
+					'startTime'    => '12:00 AM',
+					'endTime'      => '1:00 AM',
+				),
+				'gmt_offset'    => 0,
+				'current_date'  => '2023-10-01',
+				'current_time'  => '00:00:00',
+				// Expected time is today at 12:20am, since the time has not passed for today
+				'expected_time' => strtotime( '2023-10-01 00:20:00' ),
+			),
+			'GMT offset 5'              => array(
+				'settings'      => array(
+					'publishTimes' => 2,
+					'startTime'    => '12:00 AM',
+					'endTime'      => '1:00 AM',
+				),
+				'gmt_offset'    => 5,
+				'current_date'  => '2023-10-01',
+				'current_time'  => '05:00:00',
+				// Expected time is the next day at 12:20am, since the time has passed for today
+				'expected_time' => strtotime( '2023-10-02 00:20:00' ),
+			),
+			'GMT offset -3'             => array(
+				'settings'         => array(
+					'publishTimes' => 2,
+					'startTime'    => '12:00 AM',
+					'endTime'      => '1:00 AM',
+				),
+				'gmt_offset'       => -3,
+				'current_date'     => '2023-10-01',
+				'current_time_utc' => '18:00:00',
+				// Expected time is the next day at 12:20am, since the time has passed for today
+				'expected_time'    => strtotime( '2023-10-02 00:20:00' ),
+			),
+			'GMT offset -4 but its 1am' => array(
+				'settings'         => array(
+					'publishTimes' => 2,
+					'startTime'    => '12:00 AM',
+					'endTime'      => '1:00 AM',
+				),
+				'gmt_offset'       => -4,
+				'current_date'     => '2023-10-01',
+				'current_time_utc' => '01:00:00',
+				// Expected time is today at 12:20am, since the time has not passed for today
+				'expected_time'    => strtotime( '2023-10-01 00:20:00' ),
+			),
+			'GMT offset -4 but its 5am' => array(
+				'settings'         => array(
+					'publishTimes' => 2,
+					'startTime'    => '12:00 AM',
+					'endTime'      => '1:00 AM',
+				),
+				'gmt_offset'       => -4,
+				'current_date'     => '2023-10-01',
+				'current_time_utc' => '05:00:00',
+				// Expected time is the next day at 12:20am, since the time has passed for today
+				'expected_time'    => strtotime( '2023-10-02 00:20:00' ),
+			),
+			'GMT offset 5 but its 11pm' => array(
+				'settings'         => array(
+					'publishTimes' => 2,
+					'startTime'    => '12:00 AM',
+					'endTime'      => '1:00 AM',
+				),
+				'gmt_offset'       => 5,
+				'current_date'     => '2023-10-01',
+				'current_time_utc' => '23:00:00',
+				// Expected time is the next day at 12:20am, since the time has passed for today
+				'expected_time'    => strtotime( '2023-10-02 00:20:00' ),
+			),
+		);
+	}
+
+	/**
+	 * Test that the calculate_next_publish_time method uses the current start or end date when a GMT offset is passed.
+	 *
+	 * @dataProvider gmtOffsetProvider
+	 *
+	 * @param array   $settings         The settings for the manager.
+	 * @param integer $gmt_offset       The GMT offset.
+	 * @param string  $current_date     The current date.
+	 * @param string  $current_time_utc The current time in UTC.
+	 * @param integer $expected_time    The expected publish time.
+	 *
+	 * @return void
+	 */
+	public function test_calculate_next_publish_time_with_gmt_offset( $settings, $gmt_offset, $current_date, $current_time_utc, $expected_time ) {
+		$this->manager = $this->getMockBuilder( Manager::class )
+			->setConstructorArgs( array( $settings ) )
+			->onlyMethods( array( 'get_current_time', 'get_current_date' ) )
+			->getMock();
+
+		$fixed_time = strtotime( $current_date . ' ' . $current_time_utc );
+		$this->manager->method( 'get_current_time' )
+			->willReturn( $fixed_time );
+
+		$fixed_date = new \DateTime( $current_date . ' ' . $current_time_utc, new \DateTimeZone( 'UTC' ) );
+		$this->manager->method( 'get_current_date' )
+			->willReturn( $fixed_date );
+
+		$index             = 0;
+		$last_publish_time = null;
+
+		// Adjust the last_publish_time for the GMT offset
+		if ( null !== $last_publish_time ) {
+			$last_publish_time += $gmt_offset * 3600;
+		}
+
+		$next_publish_time = $this->invokeMethod( $this->manager, 'calculate_next_publish_time', array( $index, $last_publish_time, $gmt_offset ) );
+
+		$this->assertEquals( $expected_time, $next_publish_time, 'The start time should be adjusted for the GMT offset.' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-post-queue/issues/11

This PR fixes the display of the time zone on the queue page, and also displays the local time in that time zone, to aid as a reference.

To also hooks into the `update_option` hook so that we can recalculate the queue times against the new time zone when it changes.

It also adds some additional tests to make sure things are properly being calculated against the offset.

## To Test:
PHP Unit Tests: See that all checks pass below 🟢 

Manual Testing:
* Download this build and install it on a test WordPress: [wp-post-queue.zip](https://github.com/user-attachments/files/17498034/wp-post-queue.zip)
* Test different time zones (including named and +/- offsets) and make sure they display correctly on the queue page
* See that queue times are recalculated when you change the setting, and the queue times make sense

<img width="964" alt="Screenshot 2024-10-23 at 4 33 43 PM" src="https://github.com/user-attachments/assets/13b71870-f135-4ee6-ac2e-3aeed2528fd3">