### PR TITLE
Define REST params in register_rest_route with validation

### DIFF
--- a/client/settings-panel/index.js
+++ b/client/settings-panel/index.js
@@ -76,7 +76,7 @@ const SettingsPanel = ( {
 				publish_times: localPublishTimes,
 				start_time: localStartTime,
 				end_time: localEndTime,
-				wp_queue_paused: isPaused,
+				wp_queue_paused: !! isPaused,
 			} );
 
 			updateTable( response );

--- a/includes/class-wp-post-queue-rest-api.php
+++ b/includes/class-wp-post-queue-rest-api.php
@@ -15,6 +15,38 @@ class REST_API {
 	private $settings;
 
 	/**
+	 * The valid times for the queue.
+	 *
+	 * @var array
+	 */
+	private $valid_times = array(
+		'1 am',
+		'2 am',
+		'3 am',
+		'4 am',
+		'5 am',
+		'6 am',
+		'7 am',
+		'8 am',
+		'9 am',
+		'10 am',
+		'11 am',
+		'12 pm',
+		'1 pm',
+		'2 pm',
+		'3 pm',
+		'4 pm',
+		'5 pm',
+		'6 pm',
+		'7 pm',
+		'8 pm',
+		'9 pm',
+		'10 pm',
+		'11 pm',
+		'12 am',
+	);
+
+	/**
 	 * Constructor for the REST_API class.
 	 *
 	 * @param array $settings The settings for the plugin.
@@ -53,6 +85,36 @@ class REST_API {
 				'permission_callback' => function () {
 					return current_user_can( 'manage_options' );
 				},
+				'args'                => array(
+					'publish_times'   => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'validate_callback' => function ( $param, $request, $key ) {
+							return is_numeric( $param ) && $param >= 0 && $param <= 50;
+						},
+					),
+					'start_time'      => array(
+						'required'          => false,
+						'type'              => 'string',
+						'validate_callback' => function ( $param, $request, $key ) {
+							return is_string( $param ) && in_array( $param, $this->valid_times, true );
+						},
+					),
+					'end_time'        => array(
+						'required'          => false,
+						'type'              => 'string',
+						'validate_callback' => function ( $param, $request, $key ) {
+							return is_string( $param ) && in_array( $param, $this->valid_times, true );
+						},
+					),
+					'wp_queue_paused' => array(
+						'required'          => false,
+						'type'              => 'boolean',
+						'validate_callback' => function ( $param, $request, $key ) {
+							return is_bool( $param );
+						},
+					),
+				),
 			)
 		);
 
@@ -65,6 +127,23 @@ class REST_API {
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
 				},
+				'args'                => array(
+					'order' => array(
+						'required'          => true,
+						'type'              => 'array',
+						'validate_callback' => function ( $param, $request, $key ) {
+							if ( ! is_array( $param ) ) {
+								return false;
+							}
+							foreach ( $param as $id ) {
+								if ( ! is_numeric( $id ) ) {
+									return false;
+								}
+							}
+							return true;
+						},
+					),
+				),
 			)
 		);
 

--- a/tests/class-wp-post-queue-rest-api-test.php
+++ b/tests/class-wp-post-queue-rest-api-test.php
@@ -24,6 +24,10 @@ class Test_WP_Post_Queue_REST_API extends WP_UnitTestCase {
 			'wpQueuePaused' => false,
 		);
 		$this->rest_api = new REST_API( $this->settings );
+
+		// Set up an authenticated user
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
 	}
 	/**
 	 * Test that the get_settings method returns the correct settings from the database.
@@ -31,7 +35,8 @@ class Test_WP_Post_Queue_REST_API extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_settings() {
-		$settings = $this->rest_api->get_settings();
+		$fetched_response = rest_do_request( new WP_REST_Request( 'GET', '/wp-post-queue/v1/settings' ) );
+		$settings         = $fetched_response->get_data();
 
 		$this->assertIsArray( $settings );
 		$this->assertArrayHasKey( 'publishTimes', $settings );
@@ -52,16 +57,54 @@ class Test_WP_Post_Queue_REST_API extends WP_UnitTestCase {
 		$request->set_param( 'end_time', '2 am' );
 		$request->set_param( 'wp_queue_paused', true );
 
-		$response = $this->rest_api->update_settings( $request );
+		$response = rest_do_request( $request );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$this->assertEquals( 200, $response->get_status() );
 
 		$updated_settings = $this->rest_api->get_settings();
-		$this->assertEquals( 3, $updated_settings['publishTimes'] );
-		$this->assertEquals( '1 am', $updated_settings['startTime'] );
-		$this->assertEquals( '2 am', $updated_settings['endTime'] );
-		$this->assertTrue( $updated_settings['wpQueuePaused'] );
+		$fetched_response = rest_do_request( new WP_REST_Request( 'GET', '/wp-post-queue/v1/settings' ) );
+		$fetched_settings = $fetched_response->get_data();
+
+		$this->assertEquals( 3, $fetched_settings['publishTimes'] );
+		$this->assertEquals( '1 am', $fetched_settings['startTime'] );
+		$this->assertEquals( '2 am', $fetched_settings['endTime'] );
+		$this->assertTrue( $fetched_settings['wpQueuePaused'] );
+	}
+
+	/**
+	 * Data provider for invalid settings.
+	 *
+	 * @return array
+	 */
+	public function invalidSettingsProvider() {
+		return array(
+			'invalid publish_times'           => array( 'publish_times', -1 ),
+			'invalid publish_times, past max' => array( 'publish_times', 51 ),
+			'invalid start_time'              => array( 'start_time', '25 am' ),
+			'invalid end_time'                => array( 'end_time', '13 pm' ),
+			'invalid end_time, random string' => array( 'end_time', 'random string' ),
+			'invalid wp_queue_paused'         => array( 'wp_queue_paused', 'not_a_boolean' ),
+		);
+	}
+
+	/**
+	 * Test that the update_settings method returns an error for invalid parameters.
+	 *
+	 * @dataProvider invalidSettingsProvider
+	 *
+	 * @param string $param The parameter name.
+	 * @param mixed  $value The invalid value.
+	 *
+	 * @return void
+	 */
+	public function test_update_settings_invalid_parameters( $param, $value ) {
+		$request = new WP_REST_Request( 'POST', '/wp-post-queue/v1/settings' );
+		$request->set_param( $param, $value );
+
+		$response = rest_do_request( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
 	/**
@@ -79,7 +122,7 @@ class Test_WP_Post_Queue_REST_API extends WP_UnitTestCase {
 		$request = new WP_REST_Request( 'POST', '/wp-post-queue/v1/recalculate' );
 		$request->set_param( 'order', array_reverse( $post_ids ) );
 
-		$response = $this->rest_api->recalculate_publish_times_rest_callback( $request );
+		$response = rest_do_request( $request );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$this->assertEquals( 200, $response->get_status() );
@@ -88,6 +131,20 @@ class Test_WP_Post_Queue_REST_API extends WP_UnitTestCase {
 		$this->assertIsArray( $data );
 		$this->assertCount( 3, $data );
 		$this->assertEquals( $post_ids[2], $data[0]['ID'] );
+	}
+
+	/**
+	 * Test that the recalculate_publish_times_rest_callback method returns an error for invalid order.
+	 *
+	 * @return void
+	 */
+	public function test_recalculate_publish_times_invalid_order() {
+		$request = new WP_REST_Request( 'POST', '/wp-post-queue/v1/recalculate' );
+		$request->set_param( 'order', 'not_an_array' ); // Invalid value
+
+		$response = rest_do_request( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
 	/**
@@ -103,7 +160,9 @@ class Test_WP_Post_Queue_REST_API extends WP_UnitTestCase {
 			$this->factory->post->create( array( 'post_status' => 'queued' ) ),
 		);
 
-		$response = $this->rest_api->shuffle_queue();
+		$request = new WP_REST_Request( 'POST', '/wp-post-queue/v1/shuffle' );
+
+		$response = rest_do_request( $request );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$this->assertEquals( 200, $response->get_status() );
@@ -111,5 +170,63 @@ class Test_WP_Post_Queue_REST_API extends WP_UnitTestCase {
 		$data = $response->get_data();
 		$this->assertIsArray( $data );
 		$this->assertCount( 3, $data );
+	}
+
+
+	/**
+	 * Test that unauthenticated requests return a 401 Unauthorized status.
+	 *
+	 * @return void
+	 */
+	public function test_unauthenticated_requests() {
+		// Clear the current user to simulate an unauthenticated request
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'POST', '/wp-post-queue/v1/settings' );
+		$response = rest_do_request( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+
+		$post_ids = array(
+			$this->factory->post->create( array( 'post_status' => 'queued' ) ),
+			$this->factory->post->create( array( 'post_status' => 'queued' ) ),
+			$this->factory->post->create( array( 'post_status' => 'queued' ) ),
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp-post-queue/v1/recalculate' );
+		$request->set_param( 'order', array_reverse( $post_ids ) );
+
+		$response = rest_do_request( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+
+		$request  = new WP_REST_Request( 'POST', '/wp-post-queue/v1/shuffle' );
+		$response = rest_do_request( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+	}
+
+	/**
+	 * Asserts that a response is an error response.
+	 *
+	 * @param string           $code     The error code.
+	 * @param WP_REST_Response $response The response.
+	 * @param integer|null     $status   The status code.
+	 *
+	 * @return void
+	 */
+	protected function assertErrorResponse( $code, $response, $status = null ) {
+		if ( is_a( $response, 'WP_REST_Response' ) ) {
+			$response = $response->as_error();
+		}
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$this->assertEquals( $code, $response->get_error_code() );
+
+		if ( null !== $status ) {
+			$data = $response->get_error_data();
+			$this->assertArrayHasKey( 'status', $data );
+			$this->assertEquals( $status, $data['status'] );
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-post-queue/issues/8

This PR defines all of the REST parameters, with validation for the expected values.

It also adds some tests.

## To Test
* Verify that all checks (including PHP unit tests) pass below ✅ 