### PR TITLE
When the plugin is deactivated, update posts to scheduled status

### DIFF
--- a/wp-post-queue.php
+++ b/wp-post-queue.php
@@ -23,3 +23,29 @@ use WP_Post_Queue\WP_Post_Queue;
 
 $wp_post_queue = new WP_Post_Queue();
 $wp_post_queue->run();
+
+register_deactivation_hook( __FILE__, 'wp_post_queue_update_queued_posts_status' );
+
+/**
+ * Update the status of queued posts to 'scheduled' on plugin deactivation.
+ *
+ * @return void
+ */
+function wp_post_queue_update_queued_posts_status() {
+	$queued_posts = get_posts(
+		array(
+			'post_status' => 'queued',
+			'post_type'   => 'post',
+			'numberposts' => -1,
+		)
+	);
+
+	foreach ( $queued_posts as $post ) {
+		wp_update_post(
+			array(
+				'ID'          => $post->ID,
+				'post_status' => 'future',
+			)
+		);
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-post-queue/issues/14

When the plugin is deactivated, any queued posts will now get the `future` (scheduled) post status. They will retrain their previously set queued time.

## Testing Instructions
* Install the build of this branch ([wp-post-queue.zip](https://github.com/user-attachments/files/17525171/wp-post-queue.zip))
* Create a few queued posts
* Deactivate the plugin
* See that all of your previous posts are now listed under scheduled
