### PR TITLE
Add support to the Classic Editor

### DIFF
--- a/client/classic-editor/index.js
+++ b/client/classic-editor/index.js
@@ -1,4 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Hooks into the UI of the Classic Editor plugin.
@@ -72,7 +73,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 const addQueuedStatusOption = ( selectElement ) => {
 	const queuedOption = document.createElement( 'option' );
 	queuedOption.value = 'queued';
-	queuedOption.textContent = 'Queued';
+	queuedOption.textContent = __( 'Queued', 'wp-post-queue' );
 
 	// Append the "Queued" option to the dropdown
 	selectElement.appendChild( queuedOption );
@@ -104,7 +105,11 @@ const updatePublishButton = ( text ) => {
 
 	const publishButton = document.querySelector( '#publish' );
 	if ( publishButton ) {
-		publishButton.value = text;
+		const label =
+			text === 'Save'
+				? __( 'Save', 'wp-post-queue' )
+				: __( 'Queue', 'wp-post-queue' );
+		publishButton.value = label;
 		publishButton.name = 'save';
 	}
 };
@@ -123,7 +128,11 @@ const updateTimestampDisplay = async ( postStatusSelect ) => {
 		if ( queuedTime ) {
 			const timestampElement = document.querySelector( '#timestamp' );
 			if ( timestampElement ) {
-				timestampElement.innerHTML = `Schedule for: <b>${ queuedTime }</b>`;
+				timestampElement.innerHTML = sprintf(
+					/* translators: %s: The scheduled time. */
+					__( 'Schedule for: <b>%s</b>', 'wp-post-queue' ),
+					queuedTime
+				);
 			}
 		}
 	}

--- a/client/classic-editor/index.js
+++ b/client/classic-editor/index.js
@@ -1,0 +1,147 @@
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Hooks into the UI of the Classic Editor plugin.
+ *
+ * "Queued" is added as a post status option, and the publish button is updated
+ * accordingly based on the post status. We also want to show the next queued time
+ * for queued posts, and fetch that from the server.
+ */
+document.addEventListener( 'DOMContentLoaded', function () {
+	const postStatusSelect = document.querySelector(
+		'select[name="post_status"]'
+	);
+
+	if ( ! postStatusSelect ) {
+		return;
+	}
+
+	addQueuedStatusOption( postStatusSelect );
+
+	const hiddenPostStatus = document.querySelector(
+		'input[name="hidden_post_status"]'
+	);
+
+	if ( hiddenPostStatus && hiddenPostStatus.value ) {
+		postStatusSelect.value = hiddenPostStatus.value;
+	}
+
+	updatePostStatusDisplay( postStatusSelect );
+	if ( postStatusSelect.value === 'queued' ) {
+		updatePublishButton( 'Save' );
+	}
+
+	document
+		.querySelector( '.save-post-status' )
+		.addEventListener( 'click', function ( event ) {
+			event.preventDefault();
+			updatePostStatusDisplay( postStatusSelect );
+			hiddenPostStatus.value = postStatusSelect.value;
+			setTimeout( () => {
+				updatePublishButton(
+					postStatusSelect.value === 'queued' ? 'Queue' : 'Save'
+				);
+				updateTimestampDisplay( postStatusSelect );
+			}, 100 );
+		} );
+
+	document
+		.querySelector( '#publish' )
+		.addEventListener( 'click', function () {
+			const originalPostStatus = document.querySelector(
+				'input[name="original_post_status"]'
+			);
+			originalPostStatus.value = postStatusSelect.value;
+			hiddenPostStatus.value = postStatusSelect.value;
+			updatePostStatusDisplay( postStatusSelect );
+		} );
+
+	updatePublishButton();
+	updatePostStatusDisplay( postStatusSelect );
+
+	if ( wpQueuePluginData.isNewPost ) {
+		updateTimestampDisplay( postStatusSelect );
+	}
+} );
+
+/**
+ * Adds a "Queued" option to the post status dropdown.
+ *
+ * @param {HTMLElement} selectElement - The select element for the post status.
+ */
+const addQueuedStatusOption = ( selectElement ) => {
+	const queuedOption = document.createElement( 'option' );
+	queuedOption.value = 'queued';
+	queuedOption.textContent = 'Queued';
+
+	// Append the "Queued" option to the dropdown
+	selectElement.appendChild( queuedOption );
+};
+
+/**
+ * Updates the post status display to hide the edit timestamp link when the post is queued.
+ *
+ * @param {HTMLElement} postStatusSelect - The select element for the post status.
+ */
+const updatePostStatusDisplay = ( postStatusSelect ) => {
+	document.getElementById( 'post-status-display' ).textContent =
+		postStatusSelect.options[ postStatusSelect.selectedIndex ].text;
+
+	const editTimestamp = document.querySelector( '.edit-timestamp' );
+	editTimestamp.style.display =
+		postStatusSelect.value === 'queued' ? 'none' : '';
+};
+
+/**
+ * Updates the publish button text and name (action).
+ *
+ * @param {string} text - The text to set for the publish button.
+ */
+const updatePublishButton = ( text ) => {
+	if ( ! text ) {
+		return;
+	}
+
+	const publishButton = document.querySelector( '#publish' );
+	if ( publishButton ) {
+		publishButton.value = text;
+		publishButton.name = 'save';
+	}
+};
+
+/**
+ * Updates the timestamp display to show the scheduled time for queued posts.
+ *
+ * @param {HTMLElement} postStatusSelect - The select element for the post status.
+ */
+const updateTimestampDisplay = async ( postStatusSelect ) => {
+	if ( postStatusSelect.value === 'queued' ) {
+		let queuedTime = document.querySelector( '#timestamp b' ).textContent;
+		if ( wpQueuePluginData.isNewPost ) {
+			queuedTime = await fetchNextQueueTime();
+		}
+		if ( queuedTime ) {
+			const timestampElement = document.querySelector( '#timestamp' );
+			if ( timestampElement ) {
+				timestampElement.innerHTML = `Schedule for: <b>${ queuedTime }</b>`;
+			}
+		}
+	}
+};
+
+/**
+ * Fetches the next queue time from the API.
+ *
+ * @return {Promise<string|null>} The next queue time or null if there's an error.
+ */
+const fetchNextQueueTime = async () => {
+	try {
+		const data = await apiFetch( {
+			path: '/wp-post-queue/v1/next-queue-time',
+		} );
+		return data.nextQueueTime;
+	} catch ( error ) {
+		console.error( 'Error fetching next queue time:', error );
+		return null;
+	}
+};

--- a/includes/class-wp-post-queue-admin.php
+++ b/includes/class-wp-post-queue-admin.php
@@ -48,6 +48,7 @@ class Admin {
 		add_action( 'pre_get_posts', array( $this, 'set_default_queue_order' ) );
 		add_action( 'update_option_timezone_string', array( $this, 'handle_timezone_or_gmt_offset_update' ), 10, 2 );
 		add_action( 'update_option_gmt_offset', array( $this, 'handle_timezone_or_gmt_offset_update' ), 10, 2 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_classic_editor_assets' ) );
 	}
 
 	/**
@@ -68,10 +69,41 @@ class Admin {
 
 		wp_enqueue_style(
 			'wp-post-queue-editor-css',
-			plugins_url( '/client/editor/index.css', __DIR__ ),
+			plugins_url( '/build/editor.css', __DIR__ ),
 			array(),
 			WP_POST_QUEUE_VERSION
 		);
+	}
+
+	/**
+	 * Enqueue the assets for the Classic Editor.
+	 *
+	 * @param string $hook The current admin page.
+	 *
+	 * @return void
+	 */
+	public function enqueue_classic_editor_assets( $hook ) {
+		global $post;
+
+		$screen = get_current_screen();
+
+		if ( ! use_block_editor_for_post( $post ) && 'post' === $screen->base ) {
+			wp_enqueue_script(
+				'wp-post-queue-classic-editor-script',
+				plugins_url( '/build/classic-editor.js', __DIR__ ),
+				array( 'wp-api', 'wp-api-fetch' ),
+				WP_POST_QUEUE_VERSION,
+				true
+			);
+
+			wp_localize_script(
+				'wp-post-queue-classic-editor-script',
+				'wpQueuePluginData',
+				array(
+					'isNewPost' => 'post-new.php' === $hook ? true : false,
+				)
+			);
+		}
 	}
 
 	/**

--- a/includes/class-wp-post-queue-rest-api.php
+++ b/includes/class-wp-post-queue-rest-api.php
@@ -158,6 +158,18 @@ class REST_API {
 				},
 			)
 		);
+
+		register_rest_route(
+			'wp-post-queue/v1',
+			'/next-queue-time',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'get_next_queue_time' ),
+				'permission_callback' => function () {
+					return current_user_can( 'edit_posts' );
+				},
+			)
+		);
 	}
 
 	/**
@@ -267,5 +279,17 @@ class REST_API {
 		$new_order = $manager->shuffle_queued_posts();
 
 		return new \WP_REST_Response( $new_order, 200 );
+	}
+
+	/**
+	 * Get the next estimated queue time.
+	 *
+	 * @return \WP_REST_Response The next queue time.
+	 */
+	public function get_next_queue_time() {
+		$queue_manager   = new Manager( $this->settings );
+		$next_queue_time = $queue_manager->get_next_queue_time();
+
+		return new \WP_REST_Response( array( 'nextQueueTime' => $next_queue_time ), 200 );
 	}
 }

--- a/tests/class-wp-post-queue-rest-api-test.php
+++ b/tests/class-wp-post-queue-rest-api-test.php
@@ -229,4 +229,25 @@ class Test_WP_Post_Queue_REST_API extends WP_UnitTestCase {
 			$this->assertEquals( $status, $data['status'] );
 		}
 	}
+
+	/**
+	 * Test the get_next_queue_time method returns the correct next queue time.
+	 *
+	 * @return void
+	 */
+	public function test_get_next_queue_time() {
+		// Create a post with 'queued' status
+		$post_id = $this->factory->post->create( array( 'post_status' => 'queued' ) );
+
+		$request = new WP_REST_Request( 'POST', '/wp-post-queue/v1/recalculate' );
+		$request->set_param( 'order', array( $post_id ) );
+		rest_do_request( $request );
+
+		// Get the next queue time
+		$request  = new WP_REST_Request( 'GET', '/wp-post-queue/v1/next-queue-time' );
+		$response = rest_do_request( $request );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'nextQueueTime', $data );
+	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,15 @@
-const defaultConfig = require('@wordpress/scripts/config/webpack.config');
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 
 module.exports = {
-    ...defaultConfig,
-    entry: {
-        editor: './client/editor/index.js',
-        'settings-panel': './client/settings-panel/index.js',
-        'drag-drop-reorder': './client/drag-drop-reorder/index.js',
-    },
-    output: {
-        filename: '[name].js',
-        path: __dirname + '/build',
-    },
+	...defaultConfig,
+	entry: {
+		editor: './client/editor/index.js',
+		'settings-panel': './client/settings-panel/index.js',
+		'drag-drop-reorder': './client/drag-drop-reorder/index.js',
+		'classic-editor': './client/classic-editor/index.js',
+	},
+	output: {
+		filename: '[name].js',
+		path: __dirname + '/build',
+	},
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-post-queue/issues/6

This PR adds support for the Classic Editor plugin, so that those users can also use the `Queued` status.

## Testing Instructions
* Install this branch's build ([wp-post-queue.zip](https://github.com/user-attachments/files/17547454/wp-post-queue.zip))
* Install the Classic Editor plugin
* Go to `Posts > New` and then go to the `Status` drop down
* Select `Queued` and then click OK
* See that it shows your estimated queue time
* Click `Queue` and see that the button saves as expected
* Try to edit a queued post
* Try to create a normal post and make sure it functions as expected
* Try to edit a normal post and make sure it functions as expected

## Demo

https://github.com/user-attachments/assets/e649fb8a-417b-4437-8411-e42ad738b38e

