### PR TITLE
Update plugin name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # PHP
 vendor/
 .phpunit.result.cache
+wp-content/
 
 # Environment variables
 .env
@@ -30,3 +31,4 @@ build/
 
 # Plugin zip
 wp-post-queue.zip
+post-queue.zip

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -16,7 +16,7 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<element value="wp-post-queue"/>
+				<element value="post-queue"/>
 			</property>
 		</properties>
 	</rule>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WP Post Queue
+# Post Queue for WordPress
 
 This plugin is designed to help you manage and schedule your blog posts efficiently. It allows you to configure the number of posts to publish per day, set start and end times for publishing, and pause or resume the queue as needed.
 

--- a/client/classic-editor/index.js
+++ b/client/classic-editor/index.js
@@ -73,7 +73,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 const addQueuedStatusOption = ( selectElement ) => {
 	const queuedOption = document.createElement( 'option' );
 	queuedOption.value = 'queued';
-	queuedOption.textContent = __( 'Queued', 'wp-post-queue' );
+	queuedOption.textContent = __( 'Queued', 'post-queue' );
 
 	// Append the "Queued" option to the dropdown
 	selectElement.appendChild( queuedOption );
@@ -107,8 +107,8 @@ const updatePublishButton = ( text ) => {
 	if ( publishButton ) {
 		const label =
 			text === 'Save'
-				? __( 'Save', 'wp-post-queue' )
-				: __( 'Queue', 'wp-post-queue' );
+				? __( 'Save', 'post-queue' )
+				: __( 'Queue', 'post-queue' );
 		publishButton.value = label;
 		publishButton.name = 'save';
 	}
@@ -130,7 +130,7 @@ const updateTimestampDisplay = async ( postStatusSelect ) => {
 			if ( timestampElement ) {
 				timestampElement.innerHTML = sprintf(
 					/* translators: %s: The scheduled time. */
-					__( 'Schedule for: <b>%s</b>', 'wp-post-queue' ),
+					__( 'Schedule for: <b>%s</b>', 'post-queue' ),
 					queuedTime
 				);
 			}

--- a/client/editor/save-button.js
+++ b/client/editor/save-button.js
@@ -53,19 +53,16 @@ const CustomSaveButton = ( {
 			);
 			if ( publishButton ) {
 				if ( isUnsavedPost && editedStatus === 'queued' ) {
-					publishButton.textContent = __( 'Queue', 'wp-post-queue' );
+					publishButton.textContent = __( 'Queue', 'post-queue' );
 					setWasQueued( true );
 				} else if (
 					wasQueued &&
 					isUnsavedPost &&
 					( editedStatus === 'draft' || editedStatus === 'publish' )
 				) {
-					publishButton.textContent = __(
-						'Publish',
-						'wp-post-queue'
-					);
+					publishButton.textContent = __( 'Publish', 'post-queue' );
 				} else if ( wasQueued ) {
-					publishButton.textContent = __( 'Save', 'wp-post-queue' );
+					publishButton.textContent = __( 'Save', 'post-queue' );
 				}
 			}
 		};
@@ -88,7 +85,7 @@ const CustomSaveButton = ( {
 		}
 	} );
 
-	const buttonText = __( 'Save', 'wp-post-queue' );
+	const buttonText = __( 'Save', 'post-queue' );
 	const InnerSaveButton = (
 		<CustomInnerSaveButton
 			buttonText={ buttonText }

--- a/client/editor/status-selector.js
+++ b/client/editor/status-selector.js
@@ -45,13 +45,10 @@ const QueueEditorPanel = ( { onUpdateQueuedStatus } ) => {
 				input.id = `inspector-radio-control-0-${ options.length }`;
 				input.value = 'queued';
 				label.setAttribute( 'for', input.id );
-				label.childNodes[ 0 ].nodeValue = __(
-					'Queued',
-					'wp-post-queue'
-				);
+				label.childNodes[ 0 ].nodeValue = __( 'Queued', 'post-queue' );
 				span.textContent = __(
 					'Added to your publishing queue.',
-					'wp-post-queue'
+					'post-queue'
 				);
 				input.checked = currentStatusRef.current === 'queued';
 				input.removeAttribute( 'name' );
@@ -109,10 +106,7 @@ const QueueEditorPanel = ( { onUpdateQueuedStatus } ) => {
 			currentStatusRef.current = postStatus;
 			if ( isPostQueued ) {
 				setTimeout( () => {
-					postStatusButton.textContent = __(
-						'Queued',
-						'wp-post-queue'
-					);
+					postStatusButton.textContent = __( 'Queued', 'post-queue' );
 				}, 100 );
 			} else {
 				postStatusButton.textContent = '';
@@ -147,7 +141,7 @@ const EnhancedQueuePluginPanel = compose(
 	withDispatch( mapDispatchToProps )
 )( QueueEditorPanel );
 
-registerPlugin( 'wp-post-queue', {
+registerPlugin( 'post-queue', {
 	render: EnhancedQueuePluginPanel,
 	icon: 'calendar',
 } );

--- a/client/settings-panel/index.js
+++ b/client/settings-panel/index.js
@@ -66,7 +66,7 @@ const SettingsPanel = ( {
 
 		if ( startHour >= endHour ) {
 			setError(
-				__( 'The start time must be before end time.', 'wp-post-queue' )
+				__( 'The start time must be before end time.', 'post-queue' )
 			);
 			return;
 		}
@@ -84,10 +84,7 @@ const SettingsPanel = ( {
 			setIsDirty( false );
 		} catch ( saveError ) {
 			setError(
-				__(
-					'Failed to save settings. Please try again.',
-					'wp-post-queue'
-				)
+				__( 'Failed to save settings. Please try again.', 'post-queue' )
 			);
 		}
 	};
@@ -102,7 +99,7 @@ const SettingsPanel = ( {
 			setError(
 				__(
 					'Failed to pause the queue. Please try again.',
-					'wp-post-queue'
+					'post-queue'
 				)
 			);
 		}
@@ -127,7 +124,7 @@ const SettingsPanel = ( {
 			setError(
 				__(
 					'Failed to resume the queue. Please try again.',
-					'wp-post-queue'
+					'post-queue'
 				)
 			);
 			setIsLoading( false );
@@ -176,7 +173,7 @@ const SettingsPanel = ( {
 			return localTime.toLocaleString();
 		} catch ( _error ) {
 			console.error( 'Error getting local date and time:', _error );
-			return __( 'N/A', 'wp-post-queue' );
+			return __( 'N/A', 'post-queue' );
 		}
 	};
 
@@ -185,7 +182,7 @@ const SettingsPanel = ( {
 			<p>
 				{ __(
 					"The queue lets you stagger posts over a period of hours or days. It's an easy way to keep your blog active and consistent.",
-					'wp-post-queue'
+					'post-queue'
 				) }
 			</p>
 
@@ -194,7 +191,7 @@ const SettingsPanel = ( {
 					label={ _x(
 						'Automatically publish a queued post',
 						'Part of the sentence: "Automatically publish a queued post ___ times a day between ____ and ____"',
-						'wp-post-queue'
+						'post-queue'
 					) }
 					value={ localPublishTimes }
 					options={ Array.from( { length: 50 }, ( _, i ) => ( {
@@ -207,7 +204,7 @@ const SettingsPanel = ( {
 					label={ _x(
 						'times a day between',
 						'Part of the sentence: "Automatically publish a queued post ___ times a day between ____ and ____"',
-						'wp-post-queue'
+						'post-queue'
 					) }
 					value={ localStartTime }
 					options={ [
@@ -242,7 +239,7 @@ const SettingsPanel = ( {
 					label={ _x(
 						'and',
 						'Part of the sentence: "Automatically publish a queued post ___ times a day between ____ and ____"',
-						'wp-post-queue'
+						'post-queue'
 					) }
 					value={ localEndTime }
 					options={ [
@@ -285,32 +282,32 @@ const SettingsPanel = ( {
 			) }
 
 			<p>
-				{ __( 'Timezone:', 'wp-post-queue' ) }{ ' ' }
+				{ __( 'Timezone:', 'post-queue' ) }{ ' ' }
 				{ getTimezoneDisplay(
 					wpQueuePluginData.timezone,
 					wpQueuePluginData.gmtOffset
 				) }{ ' ' }
 				(
 				<a href={ wpQueuePluginData.settingsUrl }>
-					{ __( 'change', 'wp-post-queue' ) }
+					{ __( 'change', 'post-queue' ) }
 				</a>
 				)
 				<br />
-				{ __( 'Local Time:', 'wp-post-queue' ) }{ ' ' }
+				{ __( 'Local Time:', 'post-queue' ) }{ ' ' }
 				{ getLocalDateTime( wpQueuePluginData.gmtOffset ) }
 			</p>
 			<div className="settings-actions">
 				<Button isSecondary onClick={ shuffleQueue }>
-					{ __( 'Shuffle Queue', 'wp-post-queue' ) }
+					{ __( 'Shuffle Queue', 'post-queue' ) }
 				</Button>
 				{ ! isPaused && (
 					<Button isSecondary onClick={ handlePause }>
-						{ __( 'Pause Queue', 'wp-post-queue' ) }
+						{ __( 'Pause Queue', 'post-queue' ) }
 					</Button>
 				) }
 				{ isDirty && (
 					<Button isPrimary onClick={ handleSave }>
-						{ __( 'Save Changes', 'wp-post-queue' ) }
+						{ __( 'Save Changes', 'post-queue' ) }
 					</Button>
 				) }
 				{ isLoading && <Spinner /> }
@@ -324,11 +321,11 @@ const SettingsPanel = ( {
 					<p>
 						{ __(
 							'Your queue is currently paused. No queued posts will be published at this time. Scheduled posts, however, will still be published. Once the queue is un-paused, queued posts will be re-calculated and resume publication.',
-							'wp-post-queue'
+							'post-queue'
 						) }
 					</p>
 					<Button isPrimary onClick={ handleResume }>
-						{ __( 'Resume Queue', 'wp-post-queue' ) }
+						{ __( 'Resume Queue', 'post-queue' ) }
 					</Button>
 				</Notice>
 			) }

--- a/client/utils.js
+++ b/client/utils.js
@@ -33,10 +33,9 @@ export const updateTable = ( updatedPosts ) => {
 		if ( row ) {
 			const dateCell = row.querySelector( '.column-date' );
 			if ( dateCell ) {
-				dateCell.innerHTML = `${ __(
-					'Queued',
-					'wp-post-queue'
-				) }<br />${ post.date_column }`;
+				dateCell.innerHTML = `${ __( 'Queued', 'post-queue' ) }<br />${
+					post.date_column
+				}`;
 			}
 			// Reorder the row in the table
 			table.appendChild( row );

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "automattic/wp-post-queue",
+    "name": "automattic/post-queue",
     "type": "wordpress-plugin",
     "description": "A WordPress plugin designed to help you manage and schedule your blog posts efficiently. It allows you to configure the number of posts to publish per day, set start and end times for publishing, and pause or resume the queue as needed.",
     "license": "GPL-2.0-or-later",
@@ -41,7 +41,7 @@
             "@makejson"
         ],
         "makepot": "wp i18n make-pot .",
-        "updatepo": "wp i18n update-po ./languages/wp-post-queue.pot",
+        "updatepo": "wp i18n update-po ./languages/post-queue.pot",
         "makejson": "wp i18n make-json ./languages --pretty-print --no-purge",
         "makemo": "wp i18n make-mo ./languages",
         "packages-install": "@composer install --ignore-platform-reqs --no-interaction",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f390d1354799e691c117f19796ede2e",
+    "content-hash": "73610d022212192836f1f0723a21e0cb",
     "packages": [],
     "packages-dev": [
         {
@@ -2148,8 +2148,8 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
+    "platform": [],
+    "platform-dev": [],
     "platform-overrides": {
         "php": "7.4"
     },

--- a/includes/class-wp-post-queue-admin.php
+++ b/includes/class-wp-post-queue-admin.php
@@ -64,14 +64,14 @@ class Admin {
 		register_post_status(
 			'queued',
 			array(
-				'label'                     => __( 'Queued', 'wp-post-queue' ),
+				'label'                     => __( 'Queued', 'post-queue' ),
 				'public'                    => false,
 				'private'                   => true,
 				'exclude_from_search'       => true,
 				'show_in_admin_all_list'    => true,
 				'show_in_admin_status_list' => true,
 				// translators: %s is the number of posts.
-				'label_count'               => _n_noop( 'Queued <span class="count">(%s)</span>', 'Queued <span class="count">(%s)</span>', 'wp-post-queue' ),
+				'label_count'               => _n_noop( 'Queued <span class="count">(%s)</span>', 'Queued <span class="count">(%s)</span>', 'post-queue' ),
 			)
 		);
 	}
@@ -297,8 +297,8 @@ class Admin {
 	public function add_queue_menu_item() {
 		add_submenu_page(
 			'edit.php',
-			__( 'Queue', 'wp-post-queue' ),
-			__( 'Queue', 'wp-post-queue' ),
+			__( 'Queue', 'post-queue' ),
+			__( 'Queue', 'post-queue' ),
 			'edit_posts',
 			'edit.php?post_status=queued&post_type=post'
 		);
@@ -335,8 +335,8 @@ class Admin {
 		global $pagenow, $post_type;
 
 		if ( 'edit.php' === $pagenow && 'queued' === get_query_var( 'post_status' ) ) {
-			$labels->name          = __( 'Queue', 'wp-post-queue' );
-			$labels->singular_name = __( 'Queue', 'wp-post-queue' );
+			$labels->name          = __( 'Queue', 'post-queue' );
+			$labels->singular_name = __( 'Queue', 'post-queue' );
 		}
 
 		return $labels;
@@ -382,7 +382,7 @@ class Admin {
 	 */
 	public function display_post_states( $post_states, $post ) {
 		if ( get_post_status( $post->ID ) === 'queued' ) {
-			$post_states[] = __( 'Queued', 'wp-post-queue' );
+			$post_states[] = __( 'Queued', 'post-queue' );
 		}
 		return $post_states;
 	}
@@ -399,7 +399,7 @@ class Admin {
 	 */
 	public function post_date_column_status( $status, $post, $column_name, $mode ) {
 		if ( 'queued' === $post->post_status ) {
-			$status = __( 'Queued', 'wp-post-queue' );
+			$status = __( 'Queued', 'post-queue' );
 		}
 		return $status;
 	}

--- a/includes/class-wp-post-queue-manager.php
+++ b/includes/class-wp-post-queue-manager.php
@@ -313,7 +313,7 @@ class Manager {
 				'new_publish_time' => gmdate( 'Y-m-d H:i:s', $new_publish_time ),
 				'date_column'      => sprintf(
 					// translators: %1$s is the date, %2$s is the time.
-					__( '%1$s at %2$s', 'wp-post-queue' ),
+					__( '%1$s at %2$s', 'post-queue' ),
 					date_i18n( 'Y/m/d', $new_publish_time ),
 					date_i18n( 'g:i a', $new_publish_time )
 				),

--- a/languages/post-queue.pot
+++ b/languages/post-queue.pot
@@ -1,31 +1,31 @@
 # Copyright (C) 2024 Automattic
-# This file is distributed under the same license as the WP Post Queue plugin.
+# This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Post Queue 0.2.1\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-post-queue\n"
+"Project-Id-Version: Post Queue 0.2.1\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/post-queue\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-10-30T14:24:06+00:00\n"
+"POT-Creation-Date: 2024-10-30T15:16:06+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
-"X-Domain: wp-post-queue\n"
+"X-Domain: post-queue\n"
 
 #. Plugin Name of the plugin
-#: wp-post-queue.php
-msgid "WP Post Queue"
+#: post-queue.php
+msgid "Post Queue"
 msgstr ""
 
 #. Description of the plugin
-#: wp-post-queue.php
+#: post-queue.php
 msgid "A plugin to add a Tumblr-like queue feature for WordPress posts."
 msgstr ""
 
 #. Author of the plugin
-#: wp-post-queue.php
+#: post-queue.php
 msgid "Automattic"
 msgstr ""
 
@@ -39,11 +39,11 @@ msgstr ""
 #: build/settings-panel.js:197
 #: client/classic-editor/index.js:76
 #: client/editor/status-selector.js:48
-#: client/editor/status-selector.js:112
+#: client/editor/status-selector.js:109
 #: client/utils.js:36
 #: build/classic-editor.js:127
-#: build/editor.js:1629
-#: build/editor.js:1693
+#: build/editor.js:1626
+#: build/editor.js:1687
 #: build/post-list.js:36
 #: build/settings-panel.js:158
 msgid "Queued"
@@ -78,11 +78,11 @@ msgstr ""
 #: build/editor.js:1933
 #: build/editor.js:1952
 #: client/classic-editor/index.js:110
-#: client/editor/save-button.js:68
-#: client/editor/save-button.js:91
+#: client/editor/save-button.js:65
+#: client/editor/save-button.js:88
 #: build/classic-editor.js:161
-#: build/editor.js:1486
-#: build/editor.js:1509
+#: build/editor.js:1483
+#: build/editor.js:1506
 msgid "Save"
 msgstr ""
 
@@ -100,112 +100,112 @@ msgid "Publish"
 msgstr ""
 
 #: build/editor.js:2059
-#: client/editor/status-selector.js:52
-#: build/editor.js:1633
+#: client/editor/status-selector.js:49
+#: build/editor.js:1627
 msgid "Added to your publishing queue."
 msgstr ""
 
 #: build/settings-panel.js:461
 #: client/settings-panel/index.js:69
-#: build/settings-panel.js:296
+#: build/settings-panel.js:295
 msgid "The start time must be before end time."
 msgstr ""
 
 #: build/settings-panel.js:474
 #: client/settings-panel/index.js:87
-#: build/settings-panel.js:314
+#: build/settings-panel.js:313
 msgid "Failed to save settings. Please try again."
 msgstr ""
 
 #: build/settings-panel.js:484
-#: client/settings-panel/index.js:103
-#: build/settings-panel.js:330
+#: client/settings-panel/index.js:100
+#: build/settings-panel.js:326
 msgid "Failed to pause the queue. Please try again."
 msgstr ""
 
 #: build/settings-panel.js:503
-#: client/settings-panel/index.js:128
-#: build/settings-panel.js:355
+#: client/settings-panel/index.js:125
+#: build/settings-panel.js:351
 msgid "Failed to resume the queue. Please try again."
 msgstr ""
 
 #: build/settings-panel.js:543
-#: client/settings-panel/index.js:179
-#: build/settings-panel.js:406
+#: client/settings-panel/index.js:176
+#: build/settings-panel.js:402
 msgid "N/A"
 msgstr ""
 
 #: build/settings-panel.js:549
-#: client/settings-panel/index.js:186
-#: build/settings-panel.js:413
+#: client/settings-panel/index.js:183
+#: build/settings-panel.js:409
 msgid "The queue lets you stagger posts over a period of hours or days. It's an easy way to keep your blog active and consistent."
 msgstr ""
 
 #: build/settings-panel.js:553
-#: client/settings-panel/index.js:194
-#: build/settings-panel.js:421
+#: client/settings-panel/index.js:191
+#: build/settings-panel.js:417
 msgctxt "Part of the sentence: \"Automatically publish a queued post ___ times a day between ____ and ____\""
 msgid "Automatically publish a queued post"
 msgstr ""
 
 #: build/settings-panel.js:563
-#: client/settings-panel/index.js:207
-#: build/settings-panel.js:434
+#: client/settings-panel/index.js:204
+#: build/settings-panel.js:430
 msgctxt "Part of the sentence: \"Automatically publish a queued post ___ times a day between ____ and ____\""
 msgid "times a day between"
 msgstr ""
 
 #: build/settings-panel.js:571
-#: client/settings-panel/index.js:242
-#: build/settings-panel.js:469
+#: client/settings-panel/index.js:239
+#: build/settings-panel.js:465
 msgctxt "Part of the sentence: \"Automatically publish a queued post ___ times a day between ____ and ____\""
 msgid "and"
 msgstr ""
 
 #: build/settings-panel.js:585
-#: client/settings-panel/index.js:288
-#: build/settings-panel.js:515
+#: client/settings-panel/index.js:285
+#: build/settings-panel.js:511
 msgid "Timezone:"
 msgstr ""
 
 #: build/settings-panel.js:587
-#: client/settings-panel/index.js:295
-#: build/settings-panel.js:522
+#: client/settings-panel/index.js:292
+#: build/settings-panel.js:518
 msgid "change"
 msgstr ""
 
 #: build/settings-panel.js:588
-#: client/settings-panel/index.js:299
-#: build/settings-panel.js:526
+#: client/settings-panel/index.js:296
+#: build/settings-panel.js:522
 msgid "Local Time:"
 msgstr ""
 
 #: build/settings-panel.js:594
-#: client/settings-panel/index.js:304
-#: build/settings-panel.js:531
+#: client/settings-panel/index.js:301
+#: build/settings-panel.js:527
 msgid "Shuffle Queue"
 msgstr ""
 
 #: build/settings-panel.js:598
-#: client/settings-panel/index.js:308
-#: build/settings-panel.js:535
+#: client/settings-panel/index.js:305
+#: build/settings-panel.js:531
 msgid "Pause Queue"
 msgstr ""
 
 #: build/settings-panel.js:602
-#: client/settings-panel/index.js:313
-#: build/settings-panel.js:540
+#: client/settings-panel/index.js:310
+#: build/settings-panel.js:536
 msgid "Save Changes"
 msgstr ""
 
 #: build/settings-panel.js:609
-#: client/settings-panel/index.js:325
-#: build/settings-panel.js:552
+#: client/settings-panel/index.js:322
+#: build/settings-panel.js:548
 msgid "Your queue is currently paused. No queued posts will be published at this time. Scheduled posts, however, will still be published. Once the queue is un-paused, queued posts will be re-calculated and resume publication."
 msgstr ""
 
 #: build/settings-panel.js:613
-#: client/settings-panel/index.js:331
-#: build/settings-panel.js:558
+#: client/settings-panel/index.js:328
+#: build/settings-panel.js:554
 msgid "Resume Queue"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "wp-post-queue",
-  "version": "1.0.0",
+  "name": "post-queue",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wp-post-queue",
-      "version": "1.0.0",
+      "name": "post-queue",
+      "version": "0.2.1",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@wordpress/api-fetch": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wp-post-queue",
+  "name": "post-queue",
   "version": "0.2.1",
   "scripts": {
     "build": "wp-scripts build",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
     convertWarningsToExceptions="true"
 >
     <testsuites>
-        <testsuite name="WP Post Queue Tests">
+        <testsuite name="Post Queue Tests">
             <directory suffix="-test.php">./tests/</directory>
         </testsuite>
     </testsuites>

--- a/post-queue.php
+++ b/post-queue.php
@@ -1,10 +1,12 @@
 <?php
 /*
- * Plugin Name: WP Post Queue
+ * Plugin Name: Post Queue
  * Description: A plugin to add a Tumblr-like queue feature for WordPress posts.
  * Version: 0.2.1
  * Author: Automattic
- * Text Domain: wp-post-queue
+ * Text Domain: post-queue
+ * License: GPL-2.0+
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
  * Domain Path: /languages
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== WP Post Queue ===
+=== Post Queue ===
 Contributors: automattic, jshreve
 Tags: post queue, post scheduler
 Requires at least: 6.0
@@ -6,6 +6,7 @@ Tested up to: 6.6
 Stable tag: 0.2.1
 Requires PHP: 7.0
 License: GPLv2 or later
+Text Domain: post-queue
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Effortlessly queue and manage blog posts with daily limits, custom start/end times, and controls to pause or resume publishing as needed.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,7 +31,7 @@ require_once "{$_tests_dir}/includes/functions.php";
  * @return void
  */
 function _manually_load_plugin() {
-	require dirname( __DIR__ ) . '/wp-post-queue.php';
+	require dirname( __DIR__ ) . '/post-queue.php';
 }
 
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );


### PR DESCRIPTION
`WP Post Queue` is not allowed as a plugin name. This renames it to just `post-queue`